### PR TITLE
Fix setting of default keymap (#17).

### DIFF
--- a/ruby-refactor.el
+++ b/ruby-refactor.el
@@ -147,10 +147,24 @@ being altered."
   :type '(choice (const :tag "place top-most" top)
                  (const :tag "place closest" closest)))
 
+(defcustom ruby-refactor-keymap-prefix (kbd "C-c C-r")
+  "ruby-refactor keymap prefix."
+  :group 'ruby-refactor
+  :type 'sexp)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Vars
-(defvar ruby-refactor-mode-map nil
+
+(defvar ruby-refactor-mode-map
+  (let ((map (make-sparse-keymap)))
+    (let ((prefix-map (make-sparse-keymap)))
+      (define-key prefix-map (kbd "e") 'ruby-refactor-extract-to-method)
+      (define-key prefix-map (kbd "p") 'ruby-refactor-add-parameter)
+      (define-key prefix-map (kbd "l") 'ruby-refactor-extract-to-let)
+      (define-key prefix-map (kbd "v") 'ruby-refactor-extract-local-variable)
+      (define-key prefix-map (kbd "c") 'ruby-refactor-extract-constant)
+      (define-key map ruby-refactor-keymap-prefix prefix-map))
+    map)
   "Keymap to use in ruby refactor minor mode.")
 
 (defvar ruby-refactor-mode-hook nil
@@ -402,17 +416,6 @@ If a region is not selected, the transformation uses the current line."
   "Convert post conditional expression to conditional expression"
   (interactive)
   (error "Not Yet Implmented"))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Official setup and the like
-(when (not ruby-refactor-mode-map)
-  (let ((keymap (make-sparse-keymap)))
-    (define-key keymap (kbd "C-c C-r e") 'ruby-refactor-extract-to-method)
-    (define-key keymap (kbd "C-c C-r p") 'ruby-refactor-add-parameter)
-    (define-key keymap (kbd "C-c C-r l") 'ruby-refactor-extract-to-let)
-    (define-key keymap (kbd "C-c C-r v") 'ruby-refactor-extract-local-variable)
-    (define-key keymap (kbd "C-c C-r c") 'ruby-refactor-extract-constant)
-    (setq ruby-refactor-mode-map keymap)))
 
 ;;;###autoload
 (define-minor-mode ruby-refactor-mode


### PR DESCRIPTION
defvar was being called again after the variable was already set,
which doesn't work. Also, there was a typo when redefining
it (ruby-reactor-mode-map instead of ruby-refactor-mode-map). I have
followed a pattern found in other ELPA packages, such as scala-mode2,
to fix it.
