### PR TITLE
Allow user to specify an argument list when extracting a method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ In both cases, you must enable `ruby-refactor-minor-mode` in `ruby-mode`:
 
 ## Extract to Method:
 Select a region of text and invoke `ruby-refactor-extract-to-method`.
-You'll be prompted for a method name. The method will be created
-above the method you are in with the method contents being the
-selected region. The region will be replaced with a call to method.
+You'll be prompted for a method name and a new argument list. If your
+extracted method does not take parameters, leave it empty. The method
+will be created above the method you are in with the method contents
+being the selected region. The region will be replaced with a call to
+method.
 
 ## Extract Local Variable:
 Select a region o text and invoke `ruby-refactor-extract-local-variable`.

--- a/ruby-refactor.el
+++ b/ruby-refactor.el
@@ -296,6 +296,18 @@ This depends the value of `ruby-refactor-let-position'."
               (delete-blank-lines))
           (ruby-refactor-assignement-error-message))))
 
+(defun ruby-refactor-define-extracted-method (function-name argument-list function-guts)
+  (concat "def " function-name
+          (if (string= "" (ruby-refactor-trim-string argument-list))
+              ""
+            (ruby-refactor-new-params "" argument-list))
+          "\n" function-guts "\nend\n\n"))
+
+(defun ruby-refactor-generate-function-call (function-name argument-list)
+  (if (string= "" (ruby-refactor-trim-string argument-list))
+      function-name
+      (format "%s(%s)" function-name argument-list)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; API
 
@@ -308,17 +320,18 @@ This depends the value of `ruby-refactor-let-position'."
       (widen)
       (let ((ends-with-newline (ruby-refactor-ends-with-newline-p region-start region-end))
             (function-guts (ruby-refactor-trim-newline-endings (buffer-substring-no-properties region-start region-end)))
-            (function-name (read-from-minibuffer "Method name? ")))
+            (function-name (read-from-minibuffer "Method name: "))
+            (argument-list (read-from-minibuffer "Argument list (empty if none): ")))
         (delete-region region-start region-end)
         (ruby-indent-line)
-        (insert function-name)
+        (insert (ruby-refactor-generate-function-call function-name argument-list))
         (if ends-with-newline
             (progn
               (ruby-indent-line)
               (insert "\n")
               (ruby-indent-line)))
         (ruby-refactor-goto-def-start)
-        (insert "def " function-name "\n" function-guts "\nend\n\n")
+        (insert (ruby-refactor-define-extracted-method function-name argument-list function-guts))
         (ruby-refactor-goto-def-start)
         (indent-region (point)
                        (progn


### PR DESCRIPTION
When extracting a method, it's often required that the new method take in arguments (and that the replaced block provide them). Thus, when extracting a new method, ruby-refactor will ask for an optional argument list, to be specified as a comma-separated string. For instance:

``` ruby
def foo(bar)
  baz = biz
  bar.complicated_thing(baz) do
    run_complicated_logic
  end
end
```

Let's say you want to extract the bar.complicated_thing block into a method. You'll need to pass bar and baz into the new extracted method to keep things working. So, you'll do:

```
Method name: do_complicated_thing
Argument list (empty if none): bar, baz
```

That, in turn, will create the following code:

``` ruby
# Extracting the meat
def foo(bar)
  baz = biz
  do_complicated_thing(bar, baz)
end

def do_complicated_thing(bar, baz)
  bar.complicated_thing(baz) do
    run_complicated_logic
  end
end
```
