### PR TITLE
auto select based on current line and test

### DIFF
--- a/features/convert_post_condition.feature
+++ b/features/convert_post_condition.feature
@@ -1,0 +1,18 @@
+Feature: The ruby-refactor-convert-post-conditional function
+
+  Background:
+    Given I have loaded my example Ruby file
+    And I turn on ruby-mode
+    And I turn on ruby-refactor-mode
+
+  Scenario: Should convert post conditional
+    When I select "some are greater"
+    And I start an action chain
+    And I press "C-c C-r o"
+    And I execute the action chain
+    Then I should see:
+"""
+        unless long_method.empty?
+          puts "some are greater than 3"
+        end
+"""

--- a/features/example.rb
+++ b/features/example.rb
@@ -20,6 +20,10 @@ module Outer
           puts "#{value} is greater than three"
         end
       end
+
+      def has_great_than_three?
+        puts "some are greater than 3" unless long_method.empty?
+      end
     end
   end
 end

--- a/ruby-refactor.el
+++ b/ruby-refactor.el
@@ -431,8 +431,8 @@ If a region is not selected, the transformation uses the current line."
   (save-restriction
     (save-match-data
       (widen)
-      (let* ((text-begin (region-beginning))
-             (text-end (region-end))
+      (let* ((text-begin (line-beginning-position))
+             (text-end (line-end-position))
              (text (ruby-refactor-trim-newline-endings (buffer-substring-no-properties text-begin text-end)))
              (conditional
               (cond ((string-match-p "if" text) "if")
@@ -440,9 +440,9 @@ If a region is not selected, the transformation uses the current line."
                     (t (error "You need an `if' or `unless' on the target line"))))
              (line-components (ruby-refactor-trim-list (split-string text (format " %s " conditional)))))
         (delete-region text-begin text-end)
-        (insert (format "%s %s" conditional (car line-components)))
+        (insert (format "%s %s" conditional (cadr line-components)))
         (newline-and-indent)
-        (insert (format "%s" (cadr line-components)))
+        (insert (format "%s" (car line-components)))
         (newline-and-indent)
         (insert "end")
         (ruby-indent-line)


### PR DESCRIPTION
part of #12

I did two things here:
- the post condition line is now assumed to be the current line rather than having to select it (it has unexpected behavior when selecting multiple lines)
- also, (I hope this isn't just me) the conditions where being pulled out reversed

``` Ruby
puts "some are greater than 3" unless long_method.empty?
```

previously became:

``` Ruby
unless puts "some are greater than 3"
  long_method.empty?
end
```

now becomes:

``` Ruby
unless long_method.empty?
  puts "some are greater than 3"
end
```

Let me know what you think.
Thanks!
